### PR TITLE
Sync kimi-code-cli 0.14.2 parity: update identity headers, device id, and version

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,13 +8,13 @@ User-facing install / usage documentation lives in [`README.md`](./README.md). D
 
 ### Purpose
 
-One plugin, one job: make `opencode` talk to Kimi's `kimi-for-coding` endpoint **exactly the way the official `kimi-cli` does**. Everything in this repo exists to minimize drift from upstream kimi-cli.
+One plugin, one job: make `opencode` talk to Kimi's `kimi-for-coding` endpoint **exactly the way the official `kimi-code-cli` does**. Everything in this repo exists to minimize drift from upstream kimi-code-cli.
 
 ### The one rule that matters
 
 > Moonshot's coding backend is entitlement-sensitive: the model-name string alone is not the whole story.
 
-Every design decision here follows from that: we do device-flow OAuth to mirror official `kimi-cli`, we do not accept API keys in this plugin, and we do not let the upstream SDK attach its own Authorization header.
+Every design decision here follows from that: we do device-flow OAuth to mirror official `kimi-code-cli`, we do not accept API keys in this plugin, and we do not let the upstream SDK attach its own Authorization header.
 
 ### Non-goals
 
@@ -30,8 +30,8 @@ Each source file has one job. Do not add new files unless the existing ones genu
 
 | File               | Responsibility                                                                 |
 |--------------------|--------------------------------------------------------------------------------|
-| `src/constants.ts` | Pinned strings that must mirror upstream kimi-cli (version, endpoints, client id). |
-| `src/headers.ts`   | The seven `X-Msh-*` / UA headers + the persistent `~/.kimi/device_id` file.    |
+| `src/constants.ts` | Pinned strings that must mirror upstream kimi-code-cli (version, endpoints, client id). |
+| `src/headers.ts`   | The seven `X-Msh-*` / UA headers + the persistent `~/.kimi-code/device_id` file. |
 | `src/oauth.ts`     | Device-code start, device-code poll, refresh-token exchange, and `GET /coding/v1/models` discovery. |
 | `src/auth-store.ts`| Read/write opencode's `auth.json` entries for this provider.                    |
 | `src/auth-refresh.ts`| Lock-based token refresh with cross-instance coordination, `ensureFreshStoredAuth` for standalone callers. |
@@ -51,10 +51,10 @@ Data flow on a chat request:
 
 These are the invariants that, if broken, silently route requests onto the wrong auth/backend path or produce fingerprint-based throttling. Do not "clean them up" without reading the linked upstream.
 
-1. **`X-Msh-Version` and `User-Agent` must track `kimi-cli`.** Bumping involves exactly one line in `src/constants.ts`. See upstream `research/kimi-cli/src/kimi_cli/constant.py`. The UA prefix is `KimiCLI/` (not `KimiCodeCLI/`) — Moonshot's `kimi-for-coding` backend 403s with `access_terminated_error: only available for Coding Agents such as Kimi CLI, Claude Code, Roo Code…` on any other prefix. Likewise, `X-Msh-Device-Model` must mirror kimi-cli's `_device_model()` shape, including the Darwin/Windows special cases (`macOS <version> <arch>`, `Windows 10/11 <arch>`, Linux `"{system} {release} {machine}"`) — NOT just `{arch}` — and `X-Msh-Os-Version` is the kernel build string from `os.version()`, NOT `"{type} {release}"`. Tested live against `api.kimi.com/coding/v1` on 2026-04-17 — any of those three fields off-spec → 403.
-2. **`X-Msh-Device-Id` must be stable across runs.** Never regenerate a fresh UUID at import time. `getDeviceId()` reads/writes `~/.kimi/device_id`; that path is shared with `kimi-cli` on purpose.
+1. **`X-Msh-*` identity headers and `User-Agent` must track `kimi-code-cli`.** Bumping involves exactly one line in `src/constants.ts`. The UA prefix is `kimi-code-cli/` — Moonshot's `kimi-for-coding` backend 403s with `access_terminated_error: only available for Coding Agents such as Kimi CLI, Claude Code, Roo Code…` on any other prefix. `X-Msh-Platform` is `kimi_code_cli`. `X-Msh-Device-Model` uses `os.arch()` on all platforms (`macOS <version> <arch>`, `Windows <release> <arch>`, Linux `"{system} {release} {arch}"`). `X-Msh-Os-Version` is `os.release()`. Tested live against `api.kimi.com/coding/v1` on 2026-04-17 — any of those fields off-spec → 403.
+2. **`X-Msh-Device-Id` must be stable across runs.** Never regenerate a fresh UUID at import time. `getDeviceId()` reads/writes `<KIMI_CODE_HOME>/device_id` (default `~/.kimi-code/device_id`) and stores a standard UUIDv4 string (with dashes); that path is shared with `kimi-code-cli` on purpose.
 3. **`Authorization` header is owned by `loader.fetch`.** Anything else (opencode core, the SDK, future hooks) must be overridden. Our `loader` deletes both `authorization` and `Authorization` before setting its own. The private `x-opencode-kimi-*` transport headers are also consumed and stripped there; they must never leak upstream.
-4. **Effort ↔ fields mapping** (kimi-cli `llm.py` / `kosong/chat_provider/kimi.py`):
+4. **Effort ↔ fields mapping** (kimi-code-cli):
 
    | Effort   | `reasoning_effort` | `thinking`            |
    |----------|--------------------|-----------------------|
@@ -66,11 +66,11 @@ These are the invariants that, if broken, silently route requests onto the wrong
    | `xhigh`  | `"high"` (clamped) | `{type:"enabled"}`    |
    | `max`    | `"high"` (clamped) | `{type:"enabled"}`    |
 
-   `auto` is the "let the server decide dynamically" variant — neither field is sent, matching kimi-cli's "nothing passed" default. `xhigh` and `max` are clamped to `"high"` because Kimi's backend does not support higher tiers (kimi-cli's `Kimi.with_thinking()` does the same). When no effort is set at all, the plugin still emits `thinking: {type: "enabled"}` because the model is a reasoner. Compute this from `input.model.options` plus `input.model.variants[input.message.model.variant]`, not from `input.provider.info.id`. The `@opencode-ai/plugin` `ProviderContext` type claims `.info.id` exists, but the runtime shape opencode passes (see `research/opencode/packages/opencode/src/session/llm.ts::stream`, ~line 168, `provider: item`) is the flat `ProviderConfig` (`.id`). `input.model.providerID` is what every first-party plugin uses (cloudflare.ts, codex.ts, github-copilot/copilot.ts) and it avoids the runtime crash "undefined is not an object (evaluating 'input.provider.info.id')". Tested live 2026-04-17.
+   `auto` is the "let the server decide dynamically" variant — neither field is sent, matching kimi-code-cli's "nothing passed" default. `xhigh` and `max` are clamped to `"high"` because Kimi's backend does not support higher tiers. When no effort is set at all, the plugin still emits `thinking: {type: "enabled"}` because the model is a reasoner. Compute this from `input.model.options` plus `input.model.variants[input.message.model.variant]`, not from `input.provider.info.id`. The `@opencode-ai/plugin` `ProviderContext` type claims `.info.id` exists, but the runtime shape opencode passes (see `research/opencode/packages/opencode/src/session/llm.ts::stream`, ~line 168, `provider: item`) is the flat `ProviderConfig` (`.id`). `input.model.providerID` is what every first-party plugin uses (cloudflare.ts, codex.ts, github-copilot/copilot.ts) and it avoids the runtime crash "undefined is not an object (evaluating 'input.provider.info.id')". Tested live 2026-04-17.
 
 5. **`prompt_cache_key` only for `kimi-for-coding`.** Never attach it to unrelated models. The check is `input.model.id === MODEL_ID` in the Kimi chat hooks, and the actual wire injection happens in `loader.fetch`.
-6. **Wire model id comes from `/coding/v1/models`, not from user config.** The opencode-side model id is a stable alias (`MODEL_ID = "kimi-for-coding"`); the plugin calls `GET /coding/v1/models` at login and on every token refresh (mirroring kimi-cli's `refresh_managed_models` in `research/kimi-cli/src/kimi_cli/auth/platforms.py`), caches the first returned `{id, context_length, display_name, supports_image_in, supports_video_in}` in loader memory, rewrites the JSON body `model` field inside `loader.fetch` whenever the discovered id differs from `MODEL_ID`, and backfills runtime model metadata from the same discovery response. A new loader instance re-discovers on first use if needed. Do not strip the `kimi-` prefix; send whatever the server returned. Discovery failures are non-fatal (warm cached id still works; 401 retry flushes broken tokens).
-7. **Auth store is opencode's, not kimi-cli's.** We use opencode's auth store for tokens under the `kimi-for-coding-oauth` provider id. Do not read/write `~/.kimi/credentials/kimi-code.json`; that's kimi-cli's file and sharing it across independent apps causes token-race bugs. The plugin may live-read opencode's `auth.json` entry for this provider to bypass stale `OPENCODE_AUTH_CONTENT` workspace snapshots, but writes still go through opencode's auth store (`client.auth.set`). Also note that opencode's SDK auth schema only persists the standard oauth fields, so model discovery metadata cannot be stored there durably.
+6. **Wire model id comes from `/coding/v1/models`, not from user config.** The opencode-side model id is a stable alias (`MODEL_ID = "kimi-for-coding"`); the plugin calls `GET /coding/v1/models` at login and on every token refresh (mirroring kimi-code-cli's model discovery), caches the first returned `{id, context_length, display_name, supports_image_in, supports_video_in}` in loader memory, rewrites the JSON body `model` field inside `loader.fetch` whenever the discovered id differs from `MODEL_ID`, and backfills runtime model metadata from the same discovery response. A new loader instance re-discovers on first use if needed. Do not strip the `kimi-` prefix; send whatever the server returned. Discovery failures are non-fatal (warm cached id still works; 401 retry flushes broken tokens).
+7. **Auth store is opencode's, not kimi-code-cli's.** We use opencode's auth store for tokens under the `kimi-for-coding-oauth` provider id. Do not read/write `~/.kimi/credentials/kimi-code.json`; that's the legacy Python kimi-cli's file and sharing it across independent apps causes token-race bugs. The plugin may live-read opencode's `auth.json` entry for this provider to bypass stale `OPENCODE_AUTH_CONTENT` workspace snapshots, but writes still go through opencode's auth store (`client.auth.set`). Also note that opencode's SDK auth schema only persists the standard oauth fields, so model discovery metadata cannot be stored there durably.
 8. **Provider id must not collide with any id in the [models.dev](https://models.dev) catalog.** models.dev publishes `kimi-for-coding` as a separate API-key-driven integration. If we registered under that same id, `opencode auth login kimi-for-coding` would surface two methods under one entry and users could silently land on the wrong integration path. We deliberately use `kimi-for-coding-oauth` instead; `MODEL_ID` on the wire stays `kimi-for-coding` (rule 6).
 9. **`src/index.ts` must have exactly one export — the default `PluginModule` object `{ id, server }`.** opencode's plugin loader (`research/opencode/packages/opencode/src/plugin/index.ts`) first tries `readV1Plugin` (detect mode) on the default export. If it finds an object with `server` (and optional `id`), it uses the v1 path directly. The older legacy path (`getLegacyPlugins`) iterates every export and throws `Plugin export is not a function` on any non-callable value — a problem that surfaced on Windows where Bun's standalone-binary dynamic imports can produce module namespace objects with unexpected non-function metadata. The v1 format bypasses `getLegacyPlugins` entirely. Keep constants in `src/constants.ts` and import them in `src/index.ts` rather than re-exporting. `test/exports.test.ts` guards this. The failure mode of a broken export is silent in the CLI (the provider just doesn't appear in `opencode auth login`); the error only surfaces in `~/.local/share/opencode/log/*.log`.
 10. **The post-login config hint must not emit a partial `limit` object.** opencode's live config schema at `https://opencode.ai/config.json` requires both `limit.context` and `limit.output` whenever `limit` is present, while Kimi's `GET /coding/v1/models` only gives us `context_length`. Therefore `buildConfigBlock()` omits `limit` entirely and leaves `provider.models` to backfill `limit.context` at runtime. Do not invent `output` or set `input` heuristically; opencode's overflow logic treats `limit.input` as authoritative (`research/opencode/packages/opencode/src/session/overflow.ts`).
@@ -80,19 +80,19 @@ These are the invariants that, if broken, silently route requests onto the wrong
 ### Working on this repo
 
 - **Code style:** see `tsconfig.json` (strict, `noUncheckedIndexedAccess`, ES2022). Prefer small pure functions, avoid `try`/`catch` except where we genuinely convert one error shape to another.
-- **Comments:** match the existing density — only explain non-obvious upstream-parity reasoning. Do not narrate the obvious ("// refresh the token"); instead reference upstream files when the reasoning is "because kimi-cli does it that way".
+- **Comments:** match the existing density — only explain non-obvious upstream-parity reasoning. Do not narrate the obvious ("// refresh the token"); instead reference upstream files when the reasoning is "because kimi-code-cli does it that way".
 - **Dependencies:** runtime deps are limited to `@opentui/core` and `@opentui/solid` (for the TUI slash command). The only dev/peer dep is `@opencode-ai/plugin` for types. Do not add further runtime deps.
 - **Git commits:** small, logical, imperative subject ("Add oauth device flow"). Do not add a `Co-authored-by` trailer.
 - **Upstream research:** the `research/` directory is a read-only git-ignored pair of shallow clones (opencode + kimi-cli) for grep. Never edit files there; re-clone if you suspect drift. When citing upstream in a comment, use the `research/…` path so the reference is resolvable.
-- **Version bumps:** when kimi-cli bumps, (1) pull a fresh `research/kimi-cli`, (2) update `KIMI_CLI_VERSION` in `src/constants.ts`, (3) re-diff `_kimi_default_headers()` / `oauth.py` against `src/headers.ts` and `src/oauth.ts`, (4) smoke-test with `opencode auth login kimi-for-coding-oauth` and a one-turn chat, (5) tag release.
-- **Tests:** `test/` holds one file per source file plus `test/exports.test.ts` (the rule-9 guard). Tests mock `fetch` via `test/_util/fetchMock.ts`; no real credentials or network. They use the real `~/.kimi/device_id` on purpose — it is shared with kimi-cli by design and `getDeviceId` is idempotent, so tests don't clobber state. When adding a new contract to the list above, add the matching offline check to the corresponding test file rather than creating new ones.
+- **Version bumps:** when kimi-code-cli bumps, (1) pull a fresh upstream source, (2) update `KIMI_CODE_CLI_VERSION` in `src/constants.ts`, (3) re-diff the new `_common_headers()` / OAuth code against `src/headers.ts` and `src/oauth.ts`, (4) smoke-test with `opencode auth login kimi-for-coding-oauth` and a one-turn chat, (5) tag release.
+- **Tests:** `test/` holds one file per source file plus `test/exports.test.ts` (the rule-9 guard). Tests mock `fetch` via `test/_util/fetchMock.ts`; no real credentials or network. They use the real `~/.kimi-code/device_id` on purpose — it is shared with kimi-code-cli by design and `getDeviceId` is idempotent, so tests don't clobber state. When adding a new contract to the list above, add the matching offline check to the corresponding test file rather than creating new ones.
 
 ### What not to do
 
 - ❌ Don't add heuristics that look at the model id outside of the Kimi chat hooks / `loader.fetch`. The auth loader is already scoped to this provider; only the chat hooks and the body rewrite need to match on `kimi-for-coding`.
 - ❌ Don't rename the provider id back to `kimi-for-coding` or to anything else listed in models.dev. See rule 8.
-- ❌ Don't add new header values that kimi-cli doesn't send. The fingerprint matters.
-- ❌ Don't call out to other files to "share" the kimi-cli credentials. Different OAuth consumers must have independent refresh-token chains or one will invalidate the other.
+- ❌ Don't add new header values that kimi-code-cli doesn't send. The fingerprint matters.
+- ❌ Don't call out to other files to "share" the kimi-code-cli credentials. Different OAuth consumers must have independent refresh-token chains or one will invalidate the other.
 - ❌ Don't introduce a build step. The plugin ships as `.ts` and opencode's bun-based loader handles it.
 - ❌ Don't add tests that require real Kimi credentials and check them in. If you add offline unit tests, put them under `test/` and mock `fetch`.
 - ❌ Don't add named exports to `src/index.ts` or change the default export away from the `{ id, server }` PluginModule shape. See rule 9.
@@ -117,12 +117,12 @@ Online (requires a real Kimi-for-coding account):
 5. Confirm `reasoning_content` deltas render as thinking content (not assistant text).
 6. In a second turn of the same session, confirm the response comes back faster (cache hit via `prompt_cache_key`).
 
-If any of 3–6 fails, diff `research/kimi-cli` against the contracts above.
+If any of 3–6 fails, diff the upstream kimi-code-cli source against the contracts above.
 
 ### House rules for AI agents
 
 - Read this file first. Every time.
 - Don't grow the dependency footprint to "simplify" something; this plugin's value is being small and audit-able.
-- When in doubt, mirror kimi-cli exactly, then comment the upstream reference. "We used to deviate, it broke" — document it here.
+- When in doubt, mirror kimi-code-cli exactly, then comment the upstream reference. "We used to deviate, it broke" — document it here.
 - Keep `README.md` user-focused and this file contributor-focused. If you catch yourself duplicating, move content here and link from the README.
 - Any new rule you add here must have a real incident or a grep-verified upstream source behind it. No speculative "best practices".

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 ## opencode-kimi-full
 
-An [opencode](https://opencode.ai) plugin that makes the Kimi Code path in opencode work like the official `kimi-cli`, using Kimi-specific extensions instead of just a generic OpenAI-compatible provider.
+An [opencode](https://opencode.ai) plugin that makes the Kimi Code path in opencode work like the official `kimi-code-cli`, using Kimi-specific extensions instead of just a generic OpenAI-compatible provider.
 
 Compared with stock opencode Kimi setups, this plugin:
 
 - uses the official Kimi device-flow OAuth against `https://auth.kimi.com`
 - talks to `https://api.kimi.com/coding/v1` through `@ai-sdk/openai-compatible`
-- sends the same `User-Agent` / `X-Msh-*` fingerprint headers as `kimi-cli`
-- reuses `~/.kimi/device_id` for `X-Msh-Device-Id`
+- sends the same `User-Agent` / `X-Msh-*` fingerprint headers as `kimi-code-cli`
+- reuses `<KIMI_CODE_HOME>/device_id` (default `~/.kimi-code/device_id`) for `X-Msh-Device-Id`
 - adds `prompt_cache_key`, `thinking`, and `reasoning_effort` for `kimi-for-coding` requests
 - discovers the authoritative wire model slug, display name, context length, and media-input capabilities from `/coding/v1/models`
-- keeps tokens in opencode's auth store while mirroring `kimi-cli`'s refresh / retry behavior
+- keeps tokens in opencode's auth store while mirroring `kimi-code-cli`'s refresh / retry behavior
 - provides a `/kimi:usage` TUI command to check subscription usage
 
 Contributor and agent documentation lives in [`AGENTS.md`](./AGENTS.md).
@@ -28,7 +28,7 @@ Contributor and agent documentation lives in [`AGENTS.md`](./AGENTS.md).
 ### Requirements
 
 - `opencode` >= 1.4.6
-- A Kimi account with an active **Kimi For Coding** subscription (the same plan that works with kimi-cli)
+- A Kimi account with an active **Kimi For Coding** subscription (the same plan that works with kimi-code-cli)
 
 ### Install
 
@@ -193,9 +193,9 @@ These variants only affect Kimi's reasoning request fields. They do not switch m
 - `auto` leaves the decision to the server
 - `low` / `medium` / `high` ask for enabled thinking with the corresponding reasoning effort
 
-Effort levels `xhigh` and `max` are clamped to `high`, matching kimi-cli's behavior (Kimi's backend does not support higher tiers).
+Effort levels `xhigh` and `max` are clamped to `high`, matching kimi-code-cli's behavior (Kimi's backend does not support higher tiers).
 
-Every `kimi-for-coding` request also gets `prompt_cache_key` set to opencode's session id. That mirrors `kimi-cli`'s cache hint so follow-up turns in the same session can reuse Kimi's prompt cache.
+Every `kimi-for-coding` request also gets `prompt_cache_key` set to opencode's session id. That mirrors `kimi-code-cli`'s cache hint so follow-up turns in the same session can reuse Kimi's prompt cache.
 
 #### Usage command
 
@@ -206,18 +206,18 @@ The plugin registers a `/kimi:usage` TUI slash command that shows your Kimi Code
 <details>
 <summary><strong>Why this plugin exists</strong></summary>
 
-Stock opencode can already talk to generic Moonshot and OpenAI-compatible endpoints. This plugin exists for the Kimi Code path specifically: it brings the official Kimi OAuth flow and Kimi-specific request behavior into opencode without sharing `kimi-cli`'s credential files.
+Stock opencode can already talk to generic Moonshot and OpenAI-compatible endpoints. This plugin exists for the Kimi Code path specifically: it brings the official Kimi OAuth flow and Kimi-specific request behavior into opencode without sharing the legacy `kimi-cli`'s credential files.
 
 **What it adds over the generic route.**
 
 - OAuth device flow against `https://auth.kimi.com`.
 - `@ai-sdk/openai-compatible` pointed at `https://api.kimi.com/coding/v1`.
 - `prompt_cache_key` set to opencode's session id, for session-scoped cache reuse.
-- Paired `thinking` + `reasoning_effort` fields, with effort clamping to match kimi-cli.
-- The seven `X-Msh-*` headers and a kimi-cli-shaped `User-Agent`.
-- `~/.kimi/device_id` shared with a locally-installed kimi-cli.
+- Paired `thinking` + `reasoning_effort` fields, with effort clamping to match kimi-code-cli.
+- The seven `X-Msh-*` headers and a kimi-code-cli-shaped `User-Agent`.
+- `<KIMI_CODE_HOME>/device_id` shared with a locally-installed kimi-code-cli.
 - Runtime model discovery from `/coding/v1/models`, including the server-reported wire slug, `display_name`, `context_length`, and media-input capabilities.
-- Tokens stored in opencode's auth store under a dedicated provider id, so the plugin and kimi-cli keep independent refresh-token chains and do not invalidate each other.
+- Tokens stored in opencode's auth store under a dedicated provider id, so the plugin and kimi-code-cli keep independent refresh-token chains and do not invalidate each other.
 - Live auth-store rereads plus a provider-scoped refresh lock, so concurrent opencode workspaces converge on the latest refresh-token chain instead of tripping `invalid_grant`.
 - Streaming, `reasoning_content` deltas, and tool-call schemas are handled upstream by `@ai-sdk/openai-compatible` -- not reimplemented here.
 
@@ -228,11 +228,11 @@ Stock opencode can already talk to generic Moonshot and OpenAI-compatible endpoi
 
 | Field | Wire shape | Purpose |
 |---|---|---|
-| `prompt_cache_key` | top-level body, snake_case, set to opencode's `sessionID` | Opt-in, session-scoped cache key, mirroring kimi-cli. |
-| `thinking` + `reasoning_effort` | `thinking: { type: "enabled" \| "disabled" }` with sibling `reasoning_effort: "low" \| "medium" \| "high"` | Sent together, matching kimi-cli. `xhigh`/`max` clamped to `high`. |
-| Seven `X-Msh-*` headers + UA | `User-Agent`, `X-Msh-Platform`, `X-Msh-Version`, `X-Msh-Device-Name`, `X-Msh-Device-Model`, `X-Msh-Device-Id`, `X-Msh-Os-Version` | Matches kimi-cli's `_common_headers()` at the pinned `KIMI_CLI_VERSION`. |
+| `prompt_cache_key` | top-level body, snake_case, set to opencode's `sessionID` | Opt-in, session-scoped cache key, mirroring kimi-code-cli. |
+| `thinking` + `reasoning_effort` | `thinking: { type: "enabled" \| "disabled" }` with sibling `reasoning_effort: "low" \| "medium" \| "high"` | Sent together, matching kimi-code-cli. `xhigh`/`max` clamped to `high`. |
+| Seven `X-Msh-*` headers + UA | `User-Agent`, `X-Msh-Platform`, `X-Msh-Version`, `X-Msh-Device-Name`, `X-Msh-Device-Model`, `X-Msh-Device-Id`, `X-Msh-Os-Version` | Matches kimi-code-cli's `_common_headers()` at the pinned `KIMI_CODE_CLI_VERSION`. |
 | `/coding/v1/models` discovery | `id`, `display_name`, `context_length`, `supports_image_in`, `supports_video_in` | Supplies the authoritative wire model slug plus runtime model metadata. |
-| `~/.kimi/device_id` | UUID persisted on disk, embedded in `X-Msh-Device-Id` | Sends the same `X-Msh-Device-Id` as a locally-installed kimi-cli. |
+| `<KIMI_CODE_HOME>/device_id` | UUID persisted on disk, embedded in `X-Msh-Device-Id` | Sends the same `X-Msh-Device-Id` as a locally-installed kimi-code-cli. |
 
 Effort-to-field mapping used by the plugin:
 
@@ -250,10 +250,10 @@ Effort-to-field mapping used by the plugin:
 
 | Path | Purpose |
 |---|---|
-| `~/.kimi/device_id` | Stable UUID used in `X-Msh-Device-Id`. Shared with kimi-cli. |
+| `<KIMI_CODE_HOME>/device_id` | Stable UUID used in `X-Msh-Device-Id`. Shared with kimi-code-cli. |
 | opencode auth store (`auth.json` in opencode's XDG data dir; on Linux typically `~/.local/share/opencode/auth.json`) | Token storage, managed by opencode through `client.auth.*`; the plugin also live-reads this entry to avoid stale workspace auth snapshots during refresh. |
 
-No other state is persisted. Credentials are never written to `~/.kimi/credentials/`; that path belongs to kimi-cli, and sharing it would cause refresh-token races between the two clients.
+No other state is persisted. Credentials are never written to `~/.kimi/credentials/`; that path belongs to the legacy Python kimi-cli, and sharing it would cause refresh-token races between the two clients.
 
 </details>
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "opencode-kimi-full",
-  "version": "1.4.0",
-  "description": "OpenCode plugin that brings the official Kimi OAuth device flow and Kimi-specific coding request fields to opencode, matching upstream kimi-cli.",
+  "version": "2.0.0",
+  "description": "OpenCode plugin that brings the official Kimi OAuth device flow and Kimi-specific coding request fields to opencode, matching upstream kimi-code-cli.",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,18 +1,16 @@
-// Values mirror kimi-cli v1.41.0 1:1. When upstream bumps, update here and
+// Values mirror kimi-code-cli v0.14.2 1:1. When upstream bumps, update here and
 // nothing else in the codebase should hard-code these strings.
 //
-// Source of truth: research/kimi-cli/src/kimi_cli/constant.py,
-// research/kimi-cli/src/kimi_cli/auth/oauth.py
+// Source of truth: upstream kimi-code-cli version / OAuth constants.
 //
 // NOTE: client_id is a public constant shipped inside the official CLI, not a
 // secret.
 
-export const KIMI_CLI_VERSION = "1.41.0"
-// Upstream: research/kimi-cli/src/kimi_cli/constant.py get_user_agent() →
-// f"KimiCLI/{get_version()}". This must match verbatim — Moonshot's
-// `kimi-for-coding` backend 403s on any other UA prefix
+export const KIMI_CODE_CLI_VERSION = "0.14.2"
+// Upstream User-Agent is "kimi-code-cli/<version>". This must match verbatim —
+// Moonshot's `kimi-for-coding` backend 403s on any other UA prefix
 // ("access_terminated_error: only available for Coding Agents").
-export const USER_AGENT = `KimiCLI/${KIMI_CLI_VERSION}`
+export const USER_AGENT = `kimi-code-cli/${KIMI_CODE_CLI_VERSION}`
 
 export const OAUTH_HOST = "https://auth.kimi.com"
 export const OAUTH_DEVICE_AUTH_URL = `${OAUTH_HOST}/api/oauth/device_authorization`

--- a/src/headers.ts
+++ b/src/headers.ts
@@ -3,13 +3,25 @@ import fs from "node:fs"
 import path from "node:path"
 import crypto from "node:crypto"
 import childProcess from "node:child_process"
-import { KIMI_CLI_VERSION, USER_AGENT } from "./constants.ts"
+import { KIMI_CODE_CLI_VERSION, USER_AGENT } from "./constants.ts"
 
-// kimi-cli persists its device id at `~/.kimi/device_id` as a plain UUIDv4
-// hex string (no dashes). We intentionally share the same path so users who
-// also run the real kimi CLI keep a single stable fingerprint. See
-// research/kimi-cli/src/kimi_cli/auth/oauth.py (get_device_id).
-const DEVICE_ID_DIR = path.join(os.homedir(), ".kimi")
+export function kimiCodeHome(): string {
+  const override = process.env.KIMI_CODE_HOME
+  if (override !== undefined && override.length > 0) {
+    // Shells expand ~, but env vars set outside a shell do not. Match the
+    // intuitive behavior so KIMI_CODE_HOME=~/.kimi-code works as expected.
+    if (override.startsWith("~")) {
+      return path.join(os.homedir(), override.slice(1))
+    }
+    return override
+  }
+  return path.join(os.homedir(), ".kimi-code")
+}
+
+// kimi-code-cli persists its device id at `<KIMI_CODE_HOME>/device_id` as a
+// plain UUIDv4 string (with dashes). We intentionally share the same path so
+// users who also run the official kimi-code-cli keep a single stable fingerprint.
+const DEVICE_ID_DIR = kimiCodeHome()
 const DEVICE_ID_PATH = path.join(DEVICE_ID_DIR, "device_id")
 
 function ensureDir(dir: string) {
@@ -22,15 +34,15 @@ export function getDeviceId(): string {
     const existing = fs.readFileSync(DEVICE_ID_PATH, "utf8").trim()
     if (existing) return existing
   }
-  const id = crypto.randomUUID().replace(/-/g, "")
+  const id = crypto.randomUUID()
   fs.writeFileSync(DEVICE_ID_PATH, id, { mode: 0o600 })
   return id
 }
 
 // Non-ASCII characters in HTTP headers will be rejected by Node's undici
-// fetch (`TypeError: Invalid character in header content`). kimi-cli strips
-// non-ASCII bytes in oauth._ascii_header_value; we do the same while also
-// dropping control characters to stay within Node's header rules.
+// fetch (`TypeError: Invalid character in header content`). kimi-code-cli strips
+// non-ASCII bytes; we do the same while also dropping control characters to
+// stay within Node's header rules.
 export function asciiHeaderValue(value: string, fallback = "unknown"): string {
   const sanitized = value.replace(/[^\x20-\x7e]/g, "").trim()
   return sanitized || fallback
@@ -53,64 +65,65 @@ function macProductVersion(): string | undefined {
 }
 
 /**
- * Mirrors kimi-cli's `_device_model()` logic in research/kimi-cli/src/
- * kimi_cli/auth/oauth.py, including the Darwin/Windows special cases.
+ * Mirrors kimi-code-cli's device-model logic.
+ *
+ * Source: https://github.com/MoonshotAI/kimi-code/packages/oauth/src/identity.ts
+ *
+ * Uses `os.arch()` for the machine part on all platforms (Node returns values
+ * like "x64" / "arm64"), and `os.release()` for the Windows version string.
  */
 export function kimiDeviceModel(input?: {
   system?: string
   release?: string
-  machine?: string
+  arch?: string
   macVersion?: string
 }) {
   const system = input?.system ?? os.type()
   const release = input?.release ?? os.release()
-  const machine = input?.machine ?? os.machine?.() ?? os.arch()
+  const arch = input?.arch ?? os.arch()
 
   if (system === "Darwin") {
     const version = input?.macVersion ?? macProductVersion() ?? release
-    if (version && machine) return `macOS ${version} ${machine}`
+    if (version && arch) return `macOS ${version} ${arch}`
     if (version) return `macOS ${version}`
-    return `macOS ${machine}`.trim()
+    return `macOS ${arch}`.trim()
   }
 
   if (system === "Windows_NT") {
-    const parts = release.split(".")
-    const build = Number(parts[2] ?? "")
-    const label = parts[0] === "10" ? (Number.isFinite(build) && build >= 22000 ? "11" : "10") : release
-    if (label && machine) return `Windows ${label} ${machine}`
-    if (label) return `Windows ${label}`
-    return `Windows ${machine}`.trim()
+    if (release && arch) return `Windows ${release} ${arch}`
+    if (release) return `Windows ${release}`
+    return `Windows ${arch}`.trim()
   }
 
   if (system) {
-    if (release && machine) return `${system} ${release} ${machine}`
+    if (release && arch) return `${system} ${release} ${arch}`
     if (release) return `${system} ${release}`
-    return `${system} ${machine}`.trim()
+    return `${system} ${arch}`.trim()
   }
 
   return "Unknown"
 }
 
 /**
- * Builds the 7 X-Msh-* / UA headers kimi-cli sends on every request.
+ * Builds the 7 X-Msh-* / UA headers kimi-code-cli sends on every request.
  *
- * Values mirror research/kimi-cli/src/kimi_cli/auth/oauth.py → _common_headers
- * and _device_model. Deviations cause Moonshot's backend to 403 with
+ * Source: https://github.com/MoonshotAI/kimi-code/packages/oauth/src/identity.ts
+ *
+ * Deviations cause Moonshot's backend to 403 with
  * "access_terminated_error: Kimi For Coding is currently only available for
  * Coding Agents". Node equivalents:
  *   - platform.system()  → os.type()     ("Linux"/"Darwin"/"Windows_NT")
  *   - platform.release() → os.release()
- *   - platform.machine() → os.machine?.() (Node 20+ "x86_64"; NOT os.arch() which says "x64")
- *   - platform.version() → os.version()  (kernel build string on Linux)
+ *   - platform.machine() → os.arch()     (Node "x64"/"arm64")
  */
 export function kimiHeaders(): Record<string, string> {
   return {
     "User-Agent": USER_AGENT,
-    "X-Msh-Platform": "kimi_cli",
-    "X-Msh-Version": KIMI_CLI_VERSION,
+    "X-Msh-Platform": "kimi_code_cli",
+    "X-Msh-Version": KIMI_CODE_CLI_VERSION,
     "X-Msh-Device-Name": asciiHeaderValue(os.hostname() || "unknown"),
     "X-Msh-Device-Model": asciiHeaderValue(kimiDeviceModel()),
     "X-Msh-Device-Id": getDeviceId(),
-    "X-Msh-Os-Version": asciiHeaderValue(os.version?.() || `${os.type()} ${os.release()}`),
+    "X-Msh-Os-Version": asciiHeaderValue(os.release()),
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,9 +83,8 @@ function pickEffort(options: Record<string, unknown> | undefined) {
   return typeof effort === "string" ? effort : undefined
 }
 
-// kimi-cli clamps xhigh/max to "high" (research/kimi-cli/packages/kosong/
-// src/kosong/chat_provider/kimi.py, Kimi.with_thinking). Other providers
-// support higher tiers but Kimi's backend does not.
+// kimi-code-cli clamps xhigh/max to "high". Other providers support higher
+// tiers but Kimi's backend does not.
 function clampEffort(effort: string): string {
   if (effort === "xhigh" || effort === "max") return "high"
   return effort
@@ -506,12 +505,12 @@ const plugin: Plugin = async ({ client }) => {
             )
           if (!force && !isAuthExpiring(current)) return ensureDiscovered(current)
           const next = await refreshAuth(current, force)
-          // kimi-cli re-runs `refresh_managed_models` on every successful
+          // kimi-code-cli re-runs model discovery on every successful
           // refresh — we mirror that so entitlement or display-name changes
           // are picked up without a full re-login. Failures here must not
-          // block the refresh: a
-          // warm in-memory discovery still works for the common case, and
-          // the request-path 401 retry will flush a broken access token.
+          // block the refresh: a warm in-memory discovery still works for the
+          // common case, and the request-path 401 retry will flush a broken
+          // access token.
           try {
             await discoverModelInfo(next.access)
           } catch {
@@ -554,8 +553,8 @@ const plugin: Plugin = async ({ client }) => {
               // This way `input.model.id` stays `kimi-for-coding` in
               // opencode's UI/config, while Moonshot sees whatever its
               // /models endpoint says for this account (for example a
-              // non-default slug). Mirrors kimi-cli's behavior — it always sends
-              // exactly the id it got back from `/models`.
+              // non-default slug). Mirrors kimi-code-cli's behavior — it always
+              // sends exactly the id it got back from `/models`.
               let newInit = init
               const targetModel = auth.model_id
               const originalBody =
@@ -615,7 +614,7 @@ const plugin: Plugin = async ({ client }) => {
                 try {
                   const tokens = await pollDeviceToken(device)
                   // Discover the account's real model entitlement right
-                  // after approval (mirrors kimi-cli's login flow).
+                  // after approval (mirrors kimi-code-cli's login flow).
                   // Failures here degrade gracefully — the plugin still
                   // works; users just don't see the config-block hint and
                   // the loader will re-attempt discovery before the first

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -26,8 +26,7 @@ export type TokenResponse = {
 
 const REFRESH_RETRYABLE_STATUSES = new Set([429, 500, 502, 503, 504])
 const REFRESH_MAX_RETRIES = 3
-// Mirror kimi-cli's default aiohttp session timeout
-// (research/kimi-cli/src/kimi_cli/utils/aiohttp.py).
+// Mirror kimi-code-cli's default session timeout.
 const REQUEST_TIMEOUT_MS = 120_000
 
 function formBody(params: Record<string, string>): string {
@@ -64,9 +63,8 @@ async function postForm<T>(url: string, params: Record<string, string>): Promise
 }
 
 export async function startDeviceAuth(): Promise<DeviceAuth> {
-  // kimi-cli v1.41.0 dropped the `scope` parameter from the device
-  // authorization request (research/kimi-cli/src/kimi_cli/auth/oauth.py,
-  // request_device_authorization). Only `client_id` is sent now.
+  // The official kimi-code-cli drops the `scope` parameter from the device
+  // authorization request. Only `client_id` is sent now.
   return postForm<DeviceAuth>(OAUTH_DEVICE_AUTH_URL, {
     client_id: OAUTH_CLIENT_ID,
   })
@@ -172,8 +170,7 @@ export async function refreshToken(refresh: string): Promise<TokenResponse> {
 
 /**
  * Shape of each entry in `GET /coding/v1/models`. Field set mirrors what
- * kimi-cli reads — see research/kimi-cli/src/kimi_cli/auth/platforms.py
- * `_list_models`. Unused-by-this-plugin flags are kept optional for
+ * kimi-code-cli reads. Unused-by-this-plugin flags are kept optional for
  * documentation; the wire response carries them either way.
  */
 export type KimiModelInfo = {
@@ -192,8 +189,8 @@ export type KimiModelInfo = {
  * `context_length` here are the only truth about what the user is actually
  * entitled to.
  *
- * kimi-cli calls this on login and on every successful token refresh
- * (see `refresh_managed_models` in platforms.py). We do the same.
+ * kimi-code-cli calls this on login and on every successful token refresh.
+ * We do the same.
  */
 export async function listModels(accessToken: string): Promise<KimiModelInfo[]> {
   const res = await fetch(`${API_BASE_URL}/models`, {

--- a/test/constants.test.ts
+++ b/test/constants.test.ts
@@ -5,21 +5,20 @@ import * as C from "../src/constants.ts"
 // send requests down the wrong auth / backend path or collide with models.dev
 // (PROVIDER_ID). See AGENTS.md "Contracts to keep intact".
 
-test("KIMI_CLI_VERSION is a non-empty semver", () => {
-  expect(C.KIMI_CLI_VERSION).toMatch(/^\d+\.\d+\.\d+$/)
+test("KIMI_CODE_CLI_VERSION is a non-empty semver", () => {
+  expect(C.KIMI_CODE_CLI_VERSION).toMatch(/^\d+\.\d+\.\d+$/)
 })
 
-test("USER_AGENT embeds KIMI_CLI_VERSION", () => {
-  // Must be `KimiCLI/<version>` verbatim — Moonshot's backend 403s on any
-  // other UA prefix ("access_terminated_error"). See upstream
-  // research/kimi-cli/src/kimi_cli/constant.py → get_user_agent.
-  expect(C.USER_AGENT).toBe(`KimiCLI/${C.KIMI_CLI_VERSION}`)
+test("USER_AGENT embeds KIMI_CODE_CLI_VERSION", () => {
+  // Must be `kimi-code-cli/<version>` verbatim — Moonshot's backend 403s on
+  // any other UA prefix ("access_terminated_error").
+  expect(C.USER_AGENT).toBe(`kimi-code-cli/${C.KIMI_CODE_CLI_VERSION}`)
 })
 
-test("OAuth constants match upstream kimi-cli exactly", () => {
-  // Pinned values from research/kimi-cli/src/kimi_cli/auth/oauth.py. If these
-  // drift from upstream, tokens are issued against the wrong client and the
-  // plugin no longer mirrors official kimi-cli auth.
+test("OAuth constants match upstream kimi-code-cli exactly", () => {
+  // Pinned values from upstream kimi-code-cli. If these drift from upstream,
+  // tokens are issued against the wrong client and the plugin no longer
+  // mirrors official kimi-code-cli auth.
   expect(C.OAUTH_HOST).toBe("https://auth.kimi.com")
   expect(C.OAUTH_DEVICE_AUTH_URL).toBe("https://auth.kimi.com/api/oauth/device_authorization")
   expect(C.OAUTH_TOKEN_URL).toBe("https://auth.kimi.com/api/oauth/token")

--- a/test/headers.test.ts
+++ b/test/headers.test.ts
@@ -2,17 +2,18 @@ import { test, expect } from "bun:test"
 import fs from "node:fs"
 import os from "node:os"
 import path from "node:path"
-import { KIMI_CLI_VERSION, USER_AGENT } from "../src/constants.ts"
-import { asciiHeaderValue, getDeviceId, kimiDeviceModel, kimiHeaders } from "../src/headers.ts"
+import { KIMI_CODE_CLI_VERSION, USER_AGENT } from "../src/constants.ts"
+import { asciiHeaderValue, getDeviceId, kimiCodeHome, kimiDeviceModel, kimiHeaders } from "../src/headers.ts"
 
-// Note: getDeviceId() reads/writes ~/.kimi/device_id. That file is shared
-// with kimi-cli on purpose (AGENTS.md rule 2) and the function is
-// idempotent — if the file exists we reuse it, otherwise we create it. The
-// tests therefore use the real HOME: they cannot clobber anything, and
-// mocking `os.homedir` for Node's built-in `os` is fragile (Bun resolves
-// the import binding eagerly).
+// Note: getDeviceId() reads/writes <KIMI_CODE_HOME>/device_id (default
+// ~/.kimi-code/device_id), respecting the KIMI_CODE_HOME env override. That
+// file is shared with kimi-code-cli on purpose (AGENTS.md rule 2) and the
+// function is idempotent — if the file exists we reuse it, otherwise we create
+// it. The tests therefore use the real HOME: they cannot clobber anything, and
+// mocking `os.homedir` for Node's built-in `os` is fragile (Bun resolves the
+// import binding eagerly).
 
-test("kimiHeaders emits exactly the 7 fingerprint keys kimi-cli sends", () => {
+test("kimiHeaders emits exactly the 7 fingerprint keys kimi-code-cli sends", () => {
   const h = kimiHeaders()
   expect(Object.keys(h).sort()).toEqual(
     [
@@ -27,12 +28,12 @@ test("kimiHeaders emits exactly the 7 fingerprint keys kimi-cli sends", () => {
   )
 })
 
-test("User-Agent and X-Msh-Version track KIMI_CLI_VERSION (AGENTS.md rule 1)", () => {
+test("User-Agent and X-Msh-Version track KIMI_CODE_CLI_VERSION (AGENTS.md rule 1)", () => {
   const h = kimiHeaders()
   expect(h["User-Agent"]).toBe(USER_AGENT)
-  expect(h["User-Agent"]).toContain(KIMI_CLI_VERSION)
-  expect(h["X-Msh-Version"]).toBe(KIMI_CLI_VERSION)
-  expect(h["X-Msh-Platform"]).toBe("kimi_cli")
+  expect(h["User-Agent"]).toContain(KIMI_CODE_CLI_VERSION)
+  expect(h["X-Msh-Version"]).toBe(KIMI_CODE_CLI_VERSION)
+  expect(h["X-Msh-Platform"]).toBe("kimi_code_cli")
 })
 
 test("All header values are ASCII-only (undici rejects non-ASCII)", () => {
@@ -41,22 +42,24 @@ test("All header values are ASCII-only (undici rejects non-ASCII)", () => {
   }
 })
 
-test("asciiHeaderValue strips non-ASCII bytes like kimi-cli and falls back when empty", () => {
+test("asciiHeaderValue strips non-ASCII bytes like kimi-code-cli and falls back when empty", () => {
   expect(asciiHeaderValue(" hoste ")).toBe("hoste")
   expect(asciiHeaderValue("hést")).toBe("hst")
   expect(asciiHeaderValue("你好")).toBe("unknown")
 })
 
-test("Device id is a 32-char lowercase hex string (kimi-cli UUIDv4 no-dashes format)", () => {
-  expect(getDeviceId()).toMatch(/^[0-9a-f]{32}$/)
+test("Device id is a standard UUIDv4 string (kimi-code-cli format with dashes)", () => {
+  expect(getDeviceId()).toMatch(
+    /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+  )
 })
 
-test("Device id is stable across calls and matches ~/.kimi/device_id on disk (AGENTS.md rule 2)", () => {
+test("Device id is stable across calls and matches <KIMI_CODE_HOME>/device_id on disk (AGENTS.md rule 2)", () => {
   const first = getDeviceId()
   const second = getDeviceId()
   expect(second).toBe(first)
-  // Mirrors kimi-cli's path; shared by design.
-  const onDisk = fs.readFileSync(path.join(os.homedir(), ".kimi", "device_id"), "utf8").trim()
+  // Mirrors kimi-code-cli's path; shared by design.
+  const onDisk = fs.readFileSync(path.join(kimiCodeHome(), "device_id"), "utf8").trim()
   expect(onDisk).toBe(first)
 })
 
@@ -66,28 +69,46 @@ test("Device id is also present and matches in the headers map", () => {
 })
 
 // Regression guard: prior to v1.0.3 we were sending `X-Msh-Device-Model =
-// <arch>` and `X-Msh-Os-Version = <type release>`. That didn't match kimi-cli
-// and caused Moonshot to 403 every request from this plugin with
-// "access_terminated_error". Keep this tied to the helper so Linux, macOS,
-// and Windows all stay on the same parity path.
-test("X-Msh-Device-Model matches the kimi-cli parity helper", () => {
+// <arch>` and `X-Msh-Os-Version = <type release>`. That didn't match
+// kimi-code-cli and caused Moonshot to 403 every request from this plugin
+// with "access_terminated_error". Keep this tied to the helper so Linux,
+// macOS, and Windows all stay on the same parity path.
+test("X-Msh-Device-Model matches the kimi-code-cli parity helper", () => {
   const h = kimiHeaders()
   expect(h["X-Msh-Device-Model"]).toBe(asciiHeaderValue(kimiDeviceModel()))
 })
 
-test("kimiDeviceModel mirrors kimi-cli Darwin and Windows special cases", () => {
-  expect(kimiDeviceModel({ system: "Darwin", release: "23.6.0", machine: "arm64", macVersion: "15.4.1" })).toBe(
+test("kimiDeviceModel mirrors kimi-code-cli Darwin and Windows special cases", () => {
+  expect(kimiDeviceModel({ system: "Darwin", release: "23.6.0", arch: "arm64", macVersion: "15.4.1" })).toBe(
     "macOS 15.4.1 arm64",
   )
-  expect(kimiDeviceModel({ system: "Windows_NT", release: "10.0.26100", machine: "x64" })).toBe("Windows 11 x64")
-  expect(kimiDeviceModel({ system: "Windows_NT", release: "10.0.19045", machine: "x64" })).toBe("Windows 10 x64")
-  expect(kimiDeviceModel({ system: "Linux", release: "6.8.0", machine: "x86_64" })).toBe("Linux 6.8.0 x86_64")
+  expect(kimiDeviceModel({ system: "Windows_NT", release: "10.0.26100", arch: "x64" })).toBe("Windows 10.0.26100 x64")
+  expect(kimiDeviceModel({ system: "Windows_NT", release: "10.0.19045", arch: "x64" })).toBe("Windows 10.0.19045 x64")
+  expect(kimiDeviceModel({ system: "Linux", release: "6.8.0", arch: "x86_64" })).toBe("Linux 6.8.0 x86_64")
 })
 
-test("X-Msh-Os-Version matches os.version() (kernel build string on Linux)", () => {
+test("X-Msh-Os-Version matches os.release()", () => {
   const h = kimiHeaders()
-  // `os.version()` exists in Node 13.13+ — be lenient if missing.
-  if (typeof os.version === "function") {
-    expect(h["X-Msh-Os-Version"]).toBe(os.version())
+  expect(h["X-Msh-Os-Version"]).toBe(os.release())
+})
+
+test("kimiCodeHome defaults to ~/.kimi-code", () => {
+  const original = process.env.KIMI_CODE_HOME
+  delete process.env.KIMI_CODE_HOME
+  try {
+    expect(kimiCodeHome()).toBe(path.join(os.homedir(), ".kimi-code"))
+  } finally {
+    if (original !== undefined) process.env.KIMI_CODE_HOME = original
+  }
+})
+
+test("kimiCodeHome respects KIMI_CODE_HOME and expands leading ~", () => {
+  const original = process.env.KIMI_CODE_HOME
+  process.env.KIMI_CODE_HOME = "~/custom-kimi-code"
+  try {
+    expect(kimiCodeHome()).toBe(path.join(os.homedir(), "custom-kimi-code"))
+  } finally {
+    if (original !== undefined) process.env.KIMI_CODE_HOME = original
+    else delete process.env.KIMI_CODE_HOME
   }
 })

--- a/test/oauth.test.ts
+++ b/test/oauth.test.ts
@@ -10,8 +10,9 @@ import { pollDeviceToken, refreshToken, startDeviceAuth } from "../src/oauth.ts"
 import { installFetchMock, parseForm } from "./_util/fetchMock.ts"
 
 // oauth.ts calls kimiHeaders() on every request, which reads/writes
-// ~/.kimi/device_id. That file is shared with kimi-cli by design and
-// getDeviceId is idempotent — no HOME redirect needed.
+// <KIMI_CODE_HOME>/device_id (default ~/.kimi-code/device_id). That file is
+// shared with kimi-code-cli by design and getDeviceId is idempotent — no HOME
+// redirect needed.
 
 let mock: ReturnType<typeof installFetchMock> | undefined
 afterEach(() => {
@@ -40,7 +41,9 @@ test("startDeviceAuth posts client_id as form-encoded to the device endpoint", a
   expect(call.headers["content-type"]).toBe("application/x-www-form-urlencoded")
   // Fingerprint headers must be present on every oauth call, not just chat.
   expect(call.headers["x-msh-version"]).toBeDefined()
-  expect(call.headers["x-msh-device-id"]).toMatch(/^[0-9a-f]{32}$/)
+  expect(call.headers["x-msh-device-id"]).toMatch(
+    /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+  )
   expect(parseForm(call.body)).toEqual({
     client_id: OAUTH_CLIENT_ID,
   })

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -8,9 +8,9 @@ const plugin = pluginModule.server
 import { MODEL_ID, PROVIDER_ID, REFRESH_SAFETY_WINDOW_MS } from "../src/constants.ts"
 import { installFetchMock } from "./_util/fetchMock.ts"
 
-// kimiHeaders() → getDeviceId() reads/writes ~/.kimi/device_id; that file is
-// shared with kimi-cli by design and writes are idempotent — no HOME
-// redirect needed.
+// kimiHeaders() → getDeviceId() reads/writes <KIMI_CODE_HOME>/device_id
+// (default ~/.kimi-code/device_id). That file is shared with kimi-code-cli by
+// design and writes are idempotent — no HOME redirect needed.
 
 const TEST_XDG_DATA_HOME = path.join(os.tmpdir(), `opencode-kimi-full-test-${process.pid}`)
 process.env.XDG_DATA_HOME = TEST_XDG_DATA_HOME
@@ -185,7 +185,7 @@ const EFFORT_MATRIX: Array<{
   { in: { reasoning_effort: "low" }, effort: "low", thinkingType: "enabled" },
   { in: { reasoning_effort: "medium" }, effort: "medium", thinkingType: "enabled" },
   { in: { reasoning_effort: "high" }, effort: "high", thinkingType: "enabled" },
-  // kimi-cli clamps xhigh/max to "high" — Kimi's backend does not support them.
+  // kimi-code-cli clamps xhigh/max to "high" — Kimi's backend does not support them.
   { in: { reasoning_effort: "xhigh" }, effort: "high", thinkingType: "enabled" },
   { in: { reasoning_effort: "max" }, effort: "high", thinkingType: "enabled" },
   { in: {}, effort: undefined, thinkingType: "enabled" },
@@ -534,10 +534,12 @@ test("auth.loader: owns Authorization and strips any caller-supplied value (rule
   ])
   const h = mock.calls[1]!.headers
   expect(h["authorization"]).toBe(`Bearer ${jwt()}`)
-  // Seven kimi-cli fingerprint headers are attached on every request.
-  expect(h["x-msh-platform"]).toBe("kimi_cli")
+  // Seven kimi-code-cli fingerprint headers are attached on every request.
+  expect(h["x-msh-platform"]).toBe("kimi_code_cli")
   expect(h["x-msh-version"]).toBeDefined()
-  expect(h["x-msh-device-id"]).toMatch(/^[0-9a-f]{32}$/)
+  expect(h["x-msh-device-id"]).toMatch(
+    /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+  )
 })
 
 test("auth.loader: injects default thinking via private headers and strips them upstream", async () => {


### PR DESCRIPTION
## Summary

Moonshot's legacy Python `kimi-cli` is no longer updated; the new official coding agent is the TypeScript `kimi-code-cli/0.14.2`. This PR updates the plugin's wire identity and device fingerprint to match the new CLI exactly.

## Changes

- Update `User-Agent` to `kimi-code-cli/0.14.2`.
- Update `X-Msh-Platform` from `kimi_cli` to `kimi_code_cli`.
- Rename `KIMI_CLI_VERSION` → `KIMI_CODE_CLI_VERSION` and set it to `0.14.2`.
- Move device id storage from `~/.kimi/device_id` to `<KIMI_CODE_HOME>/device_id` (default `~/.kimi-code/device_id`).
- Preserve UUIDv4 dashes in device id, matching the new CLI format.
- Align `X-Msh-Device-Model` with the new CLI: use `os.arch()` everywhere and remove the Windows 10/11 build heuristic.
- Align `X-Msh-Os-Version` with `os.release()`.
- Respect `KIMI_CODE_HOME` env override for the data root.
- Update `AGENTS.md` rule 1 and device-id rule to document the new fingerprint.
- Update `README.md` and inline comments to reference `kimi-code-cli`.
- Bump package version to `2.0.0`.

## Verification

- [x] `bunx tsc --noEmit`
- [x] `bunx tsc --noEmit --project tsconfig.tests.json`
- [x] `bun build --target=node --no-bundle src/index.ts`
- [x] `bun test` — 76 pass, 0 fail

## Migration notes for users

No config change is required. The plugin automatically sends the new identity headers on the next request. A new device id will be created at `~/.kimi-code/device_id` on first use.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates identity headers, UA, and device-id storage to match `kimi-code-cli/0.14.2`, preventing 403s and restoring fingerprint parity. Bumps package to `2.0.0`.

- **Refactors**
  - Set `User-Agent` to `kimi-code-cli/0.14.2`; `X-Msh-Platform` to `kimi_code_cli`; `X-Msh-Version` to `KIMI_CODE_CLI_VERSION`.
  - Persist device id at `<KIMI_CODE_HOME>/device_id` (default `~/.kimi-code/device_id`) as a UUIDv4 with dashes; support `KIMI_CODE_HOME` with `~` expansion.
  - Build `X-Msh-Device-Model` using `os.arch()` on all platforms; `X-Msh-Os-Version` now uses `os.release()`; removed the Windows 10/11 heuristic.
  - Rename `KIMI_CLI_VERSION` → `KIMI_CODE_CLI_VERSION`; update docs/tests to reference `kimi-code-cli` and the new fingerprint.

- **Migration**
  - No action needed. New headers are sent automatically and a fresh device id is created on first use.

<sup>Written for commit 5e027697e73290e0e8c8defa156cd7f0e1200807. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lemon07r/opencode-kimi-full/pull/8?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

